### PR TITLE
Fix crash when calling Pa_CloseStream and fix compiler warnings

### DIFF
--- a/src/hostapi/opensles/pa_opensles.c
+++ b/src/hostapi/opensles/pa_opensles.c
@@ -50,8 +50,8 @@
 #include <semaphore.h>
 #include <errno.h>
 #include <math.h>
-#include <malloc.h> // malloc
-#include <string.h> // memset
+#include <malloc.h>
+#include <string.h>
 #include <time.h>
 
 #include <android/api-level.h>

--- a/src/hostapi/opensles/pa_opensles.c
+++ b/src/hostapi/opensles/pa_opensles.c
@@ -50,6 +50,7 @@
 #include <semaphore.h>
 #include <errno.h>
 #include <math.h>
+#include <string.h>
 #include <time.h>
 
 #include <android/api-level.h>

--- a/src/hostapi/opensles/pa_opensles.c
+++ b/src/hostapi/opensles/pa_opensles.c
@@ -50,7 +50,8 @@
 #include <semaphore.h>
 #include <errno.h>
 #include <math.h>
-#include <string.h>
+#include <malloc.h> // malloc
+#include <string.h> // memset
 #include <time.h>
 
 #include <android/api-level.h>
@@ -1041,6 +1042,7 @@ static void StreamProcessingCallback( void *userData )
                 (*stream->recorderItf)->SetRecordState( stream->recorderItf, SL_RECORDSTATE_STOPPED );
                 (*stream->inputBufferQueueItf)->Clear( stream->inputBufferQueueItf );
             }
+            PaUnixThreading_EXIT( paNoError );
             return;
         }
         else if( framesProcessed == 0 && !(stream->doAbort || stream->doStop) ) /* if AbortStream or StopStream weren't called, stop from the cb */
@@ -1060,7 +1062,8 @@ static void StreamProcessingCallback( void *userData )
             stream->isStopped = SL_BOOLEAN_TRUE;
             if( stream->streamRepresentation.streamFinishedCallback != NULL )
                 stream->streamRepresentation.streamFinishedCallback( stream->streamRepresentation.userData );
-           return;
+            PaUnixThreading_EXIT( paNoError );
+            return;
         }
     }
 }


### PR DESCRIPTION
# Crash fixed

Calling Pa_CloseStream would result in a crash because of attempting to free an invalid ptr.

Pa_CloseStream would call pa_opensles.c's StopStream
This would in turn call PaUnixThread_Terminate which looks at the thread's returns value via pthread_join.

If the thread's return value is not 0, portaudio interprets there's a pointer to free.

However because StreamProcessingCallback never returns a value nor calls PaUnixThreading_EXIT, there's only garbage; causing a crash when attempting to free that garbage ptr.

# Warnings fixed

Trying to build with a modern version of the NDK would give a couple:
```
portaudio_opensles/src/hostapi/opensles/pa_opensles.c:1146: warning: implicitly declaring library function 'memset' with type 'void *(void *, int, unsigned long)' [-Wimplicit-function-declaration]
            memset( stream->outputBuffers[stream->currentOutputBuffer], 0,
            ^
```

This PR fixes that warning